### PR TITLE
refactor!: rename observer to ValidateModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require spoorsny/laravel-model-validating-observer
 ## Usage
 
 Add the `ObservedBy` attribute to your model, with
-`ModelValidatingObserver::class` as its argument.
+`ValidateModel::class` as its argument.
 
 Add a public, static method to your model, named `validationRules()` that
 returns an associative array with the validation rules and custom messages for
@@ -31,9 +31,9 @@ your model's attributes.
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 
-use Spoorsny\Laravel\Observers\ModelValidatingObserver;
+use Spoorsny\Laravel\Observers\ValidateModel;
 
-#[ObservedBy(ModelValidatingObserver::class)]
+#[ObservedBy(ValidateModel::class)]
 class Car extends Model
 {
     public static function validationRules(): array

--- a/app/Observers/ValidateModel.php
+++ b/app/Observers/ValidateModel.php
@@ -40,7 +40,7 @@ use Illuminate\Support\Facades\Validator;
  * @copyright  2024 Geoffrey Bernardo van Wyk {@link https://geoffreyvanwyk.dev}
  * @license    {@link http://www.gnu.org/copyleft/gpl.html} GNU GPL v3 or later
  */
-class ModelValidatingObserver
+class ValidateModel
 {
     public function saving(Model $model): void
     {

--- a/tests/Fixtures/Models/Car.php
+++ b/tests/Fixtures/Models/Car.php
@@ -20,14 +20,15 @@ namespace Spoorsny\Laravel\Tests\Fixtures\Models;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Spoorsny\Laravel\Observers\ModelValidatingObserver;
+
+use Spoorsny\Laravel\Observers\ValidateModel;
 
 /**
  * @author     Geoffrey Bernardo van Wyk <geoffrey@vanwyk.biz>
  * @copyright  2024 Geoffrey Bernardo van Wyk {@link https://geoffreyvanwyk.dev}
  * @license    {@link http://www.gnu.org/copyleft/gpl.html} GNU GPL v3 or later
  */
-#[ObservedBy(ModelValidatingObserver::class)]
+#[ObservedBy(ValidateModel::class)]
 class Car extends Model
 {
     use HasFactory;

--- a/tests/Fixtures/Models/WithoutValidationRules.php
+++ b/tests/Fixtures/Models/WithoutValidationRules.php
@@ -20,14 +20,15 @@ namespace Spoorsny\Laravel\Tests\Fixtures\Models;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Spoorsny\Laravel\Observers\ModelValidatingObserver;
+
+use Spoorsny\Laravel\Observers\ValidateModel;
 
 /**
  * @author     Geoffrey Bernardo van Wyk <geoffrey@vanwyk.biz>
  * @copyright  2024 Geoffrey Bernardo van Wyk {@link https://geoffreyvanwyk.dev}
  * @license    {@link http://www.gnu.org/copyleft/gpl.html} GNU GPL v3 or later
  */
-#[ObservedBy(ModelValidatingObserver::class)]
+#[ObservedBy(ValidateModel::class)]
 class WithoutValidationRules extends Model
 {
     use HasFactory;

--- a/tests/Unit/ValidateModelObserverTest.php
+++ b/tests/Unit/ValidateModelObserverTest.php
@@ -17,16 +17,15 @@
 
 namespace Spoorsny\Laravel\Tests\Unit;
 
-use Illuminate\Validation\ValidationException;
 use ReflectionClass;
 
+use Illuminate\Validation\ValidationException;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 
-use Spoorsny\Laravel\Observers\ModelValidatingObserver;
+use Spoorsny\Laravel\Observers\ValidateModel;
 use Spoorsny\Laravel\Tests\Fixtures\Models\Car;
 use Spoorsny\Laravel\Tests\Fixtures\Models\WithoutValidationRules;
 use Spoorsny\Laravel\Tests\TestCase;
@@ -36,8 +35,8 @@ use Spoorsny\Laravel\Tests\TestCase;
  * @copyright  2024 Geoffrey Bernardo van Wyk {@link https://geoffreyvanwyk.dev}
  * @license    {@link http://www.gnu.org/copyleft/gpl.html} GNU GPL v3 or later
  */
-#[CoversClass(ModelValidatingObserver::class)]
-class ModelValidatingObserverTest extends TestCase
+#[CoversClass(ValidateModel::class)]
+class ValidateModelObserverTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -129,7 +128,7 @@ class ModelValidatingObserverTest extends TestCase
     }
 
     /**
-     * Assert that the class is observed by the ModelValidatingObserver::class.
+     * Assert that the class is observed by the ValidateModel::class.
      */
     private function assertObservedByMe(string $className): void
     {
@@ -137,9 +136,9 @@ class ModelValidatingObserverTest extends TestCase
 
         $observedByAttributes = array_filter($attributes, function ($attr) {
             return $attr->getName() === ObservedBy::class
-                && in_array(ModelValidatingObserver::class, $attr->getArguments());
+                && in_array(ValidateModel::class, $attr->getArguments());
         });
 
-        $this->assertTrue(count($observedByAttributes) >= 1);
+        $this->assertTrue(count($observedByAttributes) >= 1, 'Model is not observed by me.');
     }
 }


### PR DESCRIPTION
This is a better name, because it gets the point across that the class does something as opposed to being an entity that maintains state. It validates the given model while the model is being saved.

BREAKING CHANGE: class name referenced by client code is changed. The previous name will raise a fatal error.

Resolves #12